### PR TITLE
No Relationship Support in PGBuddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,12 +501,8 @@ console.log(user?.[0]?.name);
 ## Coming Soon™️ 🔮
 
 - Transaction support with type-safe rollbacks
-- Relationship handling with type inference
 - Batch operations with optimized performance
-- Migration assistance utilities
-- Query performance analytics
-- Custom operator support
-- Dynamic query building helpers
+- **TBD:** Migration assistance utilities (pgroll-to-types)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -502,7 +502,6 @@ console.log(user?.[0]?.name);
 
 - Transaction support with type-safe rollbacks
 - Batch operations with optimized performance
-- **TBD:** Migration assistance utilities (pgroll-to-types)
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pgbuddy",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pgbuddy",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgbuddy",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "A lightweight set of helper functions for Postgres.js to simplify simple CRUD operations.",
   "files": [
     "dist/*"


### PR DESCRIPTION
PGBuddy does not include relationship or join support. Implementing it requires altering the existing API and introducing complex TypeScript handling to maintain type safety. This challenge could be why many ORMs include schema generation and migration tools.

While adding a migration helper could simplify the API, this would expand the library’s scope significantly. In the future, I might explore creating a lightweight database migration assistant as a separate project, as I see a clear need for such a tool. Will see if that would improve the experience.

For now, pgBuddy remains focused on its core mission: simplifying standard database operations. This means the current API will not change, and relationship support will not be included.

## Example Comparison

**pgBuddy Query:**
```typescript
const results = await pgBuddy.table("users").select({
  select: ["users.id", "profiles.name"],
  joins: [
    {
      type: "INNER",
      table: "profiles",
      on: "users.id = profiles.user_id",
    },
  ],
  where: { "users.active": true },
  orderBy: [{ column: "users.created_at", direction: "DESC" }],
  take: 10,
});
```

**Equivalent Raw SQL:**
```sql
SELECT users.id, profiles.name
FROM users
INNER JOIN profiles ON users.id = profiles.user_id
WHERE users.active = true
ORDER BY users.created_at DESC
LIMIT 10;
```

The raw SQL is more intuitive and avoids the abstraction overhead in this case. In my opinion, Complex queries like this are better handled directly with SQL, keeping pgBuddy focused on simplifying standard database operations.

## For Custom Needs
If you want relationship support, feel free to fork the library. Here’s a basic starting point to get the typesafety for joins:
```typescript
type StringKeys<T> = Extract<keyof T, string>;
type TableColumns<T> = { [K in StringKeys<T>]: T[K] extends object ? never : K }[StringKeys<T>];
type QualifiedColumn<T, Tables extends string> = `${Tables}.${TableColumns<T>}`;

```
